### PR TITLE
Hide next lesson option after completing ninth stage

### DIFF
--- a/app/src/main/java/com/ukyo/kukutrainer/ui/learning/CompletionScreen.kt
+++ b/app/src/main/java/com/ukyo/kukutrainer/ui/learning/CompletionScreen.kt
@@ -66,9 +66,15 @@ fun CompletionScreen(stage: Int, navController: NavHostController) {
         )
     }
 
+    val nextLesson: (() -> Unit)? = if (stage < 9) {
+        { navController.navigate(Screen.Learning.createRoute(stage + 1)) }
+    } else {
+        null
+    }
+
     CompletionContent(
         completionData = completionData,
-        onNextLessonClicked = { navController.navigate(Screen.Learning.createRoute(stage + 1)) },
+        onNextLessonClicked = nextLesson,
         onBackToMenuClicked = { navController.navigate(Screen.Home.route) }
     )
 }
@@ -79,7 +85,7 @@ fun CompletionScreen(stage: Int, navController: NavHostController) {
 @Composable
 fun CompletionContent(
     completionData: CompletionData,
-    onNextLessonClicked: () -> Unit = {},
+    onNextLessonClicked: (() -> Unit)? = null,
     onBackToMenuClicked: () -> Unit = {}
 ) {
     // Animation states
@@ -467,39 +473,41 @@ private fun NewBadgesSection(badges: List<String>) {
 
 @Composable
 private fun ActionButtons(
-    onNextLessonClicked: () -> Unit,
+    onNextLessonClicked: (() -> Unit)?,
     onBackToMenuClicked: () -> Unit
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Button(
-            onClick = onNextLessonClicked,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(56.dp)
-                .shadow(8.dp, RoundedCornerShape(28.dp)),
-            shape = RoundedCornerShape(28.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color(0xFF4CAF50)
-            )
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
+        onNextLessonClicked?.let {
+            Button(
+                onClick = it,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .shadow(8.dp, RoundedCornerShape(28.dp)),
+                shape = RoundedCornerShape(28.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF4CAF50)
+                )
             ) {
-                Text(
-                    text = "つぎのレッスン",
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = Color.White
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "🚀",
-                    fontSize = 20.sp
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = "つぎのレッスン",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "🚀",
+                        fontSize = 20.sp
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- stop showing the "next lesson" button after clearing stage 9
- make completion screen's next lesson action optional and render button only when available

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bff00998f48332948e1ef48402f2d7