### PR TITLE
Stop overlapping audio during learning

### DIFF
--- a/app/src/main/java/com/ukyo/kukutrainer/audio/AudioUtils.kt
+++ b/app/src/main/java/com/ukyo/kukutrainer/audio/AudioUtils.kt
@@ -7,40 +7,41 @@ import com.ukyo.kukutrainer.R
 /**
  * Plays a recorded multiplication sound from the raw resources.
  * Files should be named in the pattern `kuku_{{left}}_{{right}}`.
- * Returns true if the audio was played, or false if the resource doesn't exist.
+ * Returns the [MediaPlayer] instance if the audio was played, or null if the resource doesn't exist.
  */
-fun playRecordedKuku(context: Context, left: Int, right: Int): Boolean {
+fun playRecordedKuku(context: Context, left: Int, right: Int): MediaPlayer? {
     val resName = "kuku_${left}_${right}"
     val resId = context.resources.getIdentifier(resName, "raw", context.packageName)
     if (resId == 0) {
-        return false
+        return null
     }
-    val player = MediaPlayer.create(context, resId) ?: return false
+    val player = MediaPlayer.create(context, resId) ?: return null
     player.setOnCompletionListener { mp ->
         mp.release()
     }
     return try {
         player.start()
-        true
+        player
     } catch (e: Exception) {
         player.release()
-        false
+        null
     }
 }
-    /**
-     * Plays a simple feedback sound to indicate whether the answer was
-     * correct or incorrect. The sound resource is released automatically
-     * after playback finishes.
-     */
-    fun playFeedbackSound(context: Context, isCorrect: Boolean) {
-        val resId = if (isCorrect) R.raw.pinpon else R.raw.bubu
-        val player = MediaPlayer.create(context, resId)
-        player?.setOnCompletionListener { mp ->
-            mp.release()
-        }
-        try {
-            player?.start()
-        } catch (e: Exception) {
-            player?.release()
-        }
+
+/**
+ * Plays a simple feedback sound to indicate whether the answer was
+ * correct or incorrect. The sound resource is released automatically
+ * after playback finishes.
+ */
+fun playFeedbackSound(context: Context, isCorrect: Boolean) {
+    val resId = if (isCorrect) R.raw.pinpon else R.raw.bubu
+    val player = MediaPlayer.create(context, resId)
+    player?.setOnCompletionListener { mp ->
+        mp.release()
     }
+    try {
+        player?.start()
+    } catch (e: Exception) {
+        player?.release()
+    }
+}

--- a/app/src/main/java/com/ukyo/kukutrainer/ui/learning/LearningScreen.kt
+++ b/app/src/main/java/com/ukyo/kukutrainer/ui/learning/LearningScreen.kt
@@ -85,8 +85,14 @@ fun LearningScreen(stage: Int, navController: NavHostController) {
 
     fun playAudio() {
         if (!voiceEnabled) return
-        mediaPlayer?.release()
-        if (!playRecordedKuku(context, stage, currentIndex)) {
+        mediaPlayer?.let { mp ->
+            if (mp.isPlaying) {
+                mp.stop()
+            }
+            mp.release()
+        }
+        mediaPlayer = playRecordedKuku(context, stage, currentIndex)
+        if (mediaPlayer == null) {
             val text = context.getString(
                 R.string.learning_expression_format,
                 stage,
@@ -100,6 +106,14 @@ fun LearningScreen(stage: Int, navController: NavHostController) {
     }
 
     fun nextProblem() {
+        tts?.stop()
+        mediaPlayer?.let { mp ->
+            if (mp.isPlaying) {
+                mp.stop()
+            }
+            mp.release()
+            mediaPlayer = null
+        }
         if (currentIndex < 9) {
             currentIndex++
         } else {


### PR DESCRIPTION
## Summary
- Track and stop current MediaPlayer so audio doesn't overlap when moving to the next learning problem
- Return MediaPlayer from `playRecordedKuku` to allow proper release

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bff0ec40208332b73e8fbbbce69734