### PR TITLE
Display all profile badges without scrolling

### DIFF
--- a/app/src/main/java/com/ukyo/kukutrainer/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/ukyo/kukutrainer/ui/profile/ProfileScreen.kt
@@ -16,8 +16,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -240,6 +240,7 @@ private fun CharacterSection(info: Pair<String, Int>?) {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun BadgeSection(badges: List<Badge>) {
     Card(
@@ -262,10 +263,11 @@ private fun BadgeSection(badges: List<Badge>) {
                 modifier = Modifier.padding(bottom = 12.dp)
             )
 
-            LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                items(badges) { badge ->
+                badges.forEach { badge ->
                     BadgeItem(badge = badge)
                 }
             }


### PR DESCRIPTION
## Summary
- Replace horizontal badge list with a multi-line FlowRow to show all cleared stages at once

## Testing
- `./gradlew test` *(fails: Unable to download Gradle distribution, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c0091e21948332a09d6fd39a467e71